### PR TITLE
Fix link to demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ choose the form layout. `react-bootstrap` is used for the React components.
 
 A pure Rails UI generated from scaffolding is shown for comparison.
 
-You can see this tutorial live here: [http://react-webpack-rails-tutorial.herokuapp.com/]()
+You can see this tutorial live here: [http://react-webpack-rails-tutorial.herokuapp.com/](http://react-webpack-rails-tutorial.herokuapp.com/)
 
 # Motivation
 


### PR DESCRIPTION
Currently links to: https://github.com/justin808/react-webpack-rails-tutorial/blob/master when you click the demo app link