### PR TITLE
Enable rails logging with Foreman

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: rails s -p 4000
 client: cd client && $(npm bin)/webpack -w --config webpack.rails.config.js
 hot: cd client && node server.js
+log: tail -f log/development.log


### PR DESCRIPTION
I was finding that more often than not my rails logs were being swallowed by Foreman.  This should fix that.