### PR TITLE
Add rake task that delete all the comments older than one day

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,0 +1,5 @@
+desc "Remove all comments older than one day"
+task :rm_comments => :environment do
+  puts "Removing comments older than one day"
+  Comment.delete_all(:created_at => Time.now.midnight - 1.year..Time.now.midnight - 1.day)
+end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,5 +1,9 @@
 desc "Remove all comments older than one day"
 task :rm_comments => :environment do
   puts "Removing comments older than one day"
-  Comment.delete_all(created_at: Time.now.midnight - 1.year..Time.now.midnight - 1.day)
+  #Comment.delete_all(created_at: Time.now.midnight - 1.year..Time.now.midnight - 1.day)
+  #sql = "DELETE FROM comments WHERE created_at <= date('now','-1 day')"
+  #sql = "DELETE FROM comments WHERE created_at < now()-'1 day'"
+  sql = "DELETE FROM comments WHERE created_at < now() - interval '1 day'"
+  ActiveRecord::Base.connection.execute(sql)
 end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,5 +1,5 @@
 desc "Remove all comments older than one day"
 task :rm_comments => :environment do
   puts "Removing comments older than one day"
-  Comment.delete_all(:created_at => Time.now.midnight - 1.year..Time.now.midnight - 1.day)
+  Comment.delete_all(created_at: Time.now.midnight - 1.year..Time.now.midnight - 1.day)
 end


### PR DESCRIPTION
Add rake task for heroku scheduler.
1. Install scheduler addon: `heroku addons:create scheduler:standard`.
2. Deploy task to heroku.
3. Run `heroku run rake rm_comments` for test. **It will delete all comments from project page.**
4. Open scheduler page `heroku addons:open scheduler`.
5. Set it like this: ![scheduler page](http://i.gyazo.com/436fbb3b75dcea4e0a9fbef5c13c5cbe.png)